### PR TITLE
Allowing interpolation in the middle of a value

### DIFF
--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -42,6 +42,13 @@ a: ${A}
 b: 2
         '''), {'a': 'password', 'b': 2})
 
+    def test_interpolate_within_characters(self):
+        os.environ['A'] = 'def'
+        self.assertEqual(yamlenv.load('''
+a: abc${A}ghi
+b: 2
+        '''), {'a': 'abcdefghi', 'b': 2})
+
     def test_interpolate_string_alternative_separator(self):
         os.environ['A'] = 'password'
         self.assertEqual(yamlenv.load('''

--- a/yamlenv/env.py
+++ b/yamlenv/env.py
@@ -28,20 +28,21 @@ def objwalk(obj, path=(), memo=None):
 
 
 class EnvVar(object):
-    __slots__ = ['name', 'default']
+    __slots__ = ['name', 'default', 'string']
 
     RE = re.compile(
         r'\$\{(?P<name>[^:-]+)(?:(?P<separator>:?-)(?P<default>.+))?\}')
 
-    def __init__(self, name, default):
+    def __init__(self, name, default, string):
         self.name = name
         self.default = default
+        self.string = string
 
     @property
     def value(self):
         value = os.environ.get(self.name)
         if value:
-            return value
+            return self.RE.sub(value, self.string)
         if self.default:
             return self.default
         raise ValueError('Missing value and default for {}'.format(self.name))
@@ -50,11 +51,11 @@ class EnvVar(object):
     def from_string(cls, s):
         if not isinstance(s, six.string_types):
             return None
-        data = cls.RE.match(s)
+        data = cls.RE.search(s)
         if not data:
             return None
         data = data.groupdict()
-        return cls(data['name'], data['default'])
+        return cls(data['name'], data['default'], s)
 
 
 def interpolate(data):


### PR DESCRIPTION
Currently, the library doesn't interpolate env vars if they're contained in bigger strings. For instance, `https://${URL_BASE}/some/path` won't be interpolated.

This pull request introduces the ability to interpolate these cases.