### PR TITLE
Import abstract base classes from collections.abc where available.

### DIFF
--- a/yamlenv/env.py
+++ b/yamlenv/env.py
@@ -1,7 +1,12 @@
 # pylint: disable=undefined-variable
-from collections import Mapping, Set, Sequence
 import os
 import re
+
+try:
+    from collections.abc import Mapping, Sequence, Set
+except ImportError:
+    # Python 2.7
+    from collections import Mapping, Sequence, Set  # noqa
 
 import six
 


### PR DESCRIPTION
 Avoids warning on Python 3.7, failure on Python 3.8, and fixes #3.