### PR TITLE
Allow interpolated values to be processed as YAML literals.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,18 @@ and an environmental variable ``$A`` with value ``hello``,
         b: 2
     }
 
+Including YAML literals as environment variables is also
+supported - so if the environment variable ``$A`` was set to
+``false``, ``yamlenv.load`` would return:
+
+.. code-block:: python
+
+    {
+        a: False,
+        b: 2
+    }
+
+
 Default values are supported:
 
 .. code-block:: python

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -33,7 +33,7 @@ b: 2
         self.assertEqual(yamlenv.load('''
 a: ${A}
 b: 2
-            '''), {'a': '1', 'b': 2})
+            '''), {'a': 1, 'b': 2})
 
     def test_interpolate_string(self):
         os.environ['A'] = 'password'
@@ -67,13 +67,13 @@ b: 2
         self.assertEqual(yamlenv.load('''
 a: ${A-1}
 b: 2
-            '''), {'a': '1', 'b': 2})
+            '''), {'a': 1, 'b': 2})
 
     def test_interpolate_default_alternative_separator(self):
         self.assertEqual(yamlenv.load('''
 a: ${A:-1}
 b: 2
-            '''), {'a': '1', 'b': 2})
+            '''), {'a': 1, 'b': 2})
 
     def test_interpolate_nested(self):
         self.assertEqual(yamlenv.load('''
@@ -81,17 +81,28 @@ a: 1
 b:
   b1: 21
   b2: ${B-22}
-            '''), {'a': 1, 'b': {'b1': 21, 'b2': '22'}})
+            '''), {'a': 1, 'b': {'b1': 21, 'b2': 22}})
 
     def test_interpolate_embedded(self):
         self.assertEqual(yamlenv.load('''
 a: ${FOO:-foo} bar
 '''), {'a': 'foo bar'})
 
+    def test_interpolate_embedded_integer(self):
+        self.assertEqual(yamlenv.load('''
+a: ${FOO:-7} bar
+'''), {'a': '7 bar'})
+
+
+    def test_interpolate_default_empty(self):
+        self.assertEqual(yamlenv.load('''
+a: bar ${FOO-} bar
+'''), {'a': 'bar  bar'})
+
     def test_default_empty(self):
         self.assertEqual(yamlenv.load('''
-a: ${FOO-} bar
-'''), {'a': ' bar'})
+a: ${FOO-}
+'''), {'a': None})
 
     def test_default_does_not_exist(self):
         with self.assertRaises(ValueError):

--- a/yamlenv/env.py
+++ b/yamlenv/env.py
@@ -62,6 +62,10 @@ class EnvVar(object):
             return self.RE.sub(self.default, self.string)
         raise ValueError('Missing value and default for {}'.format(self.name))
 
+    @property
+    def yaml_value(self):
+        return yaml.safe_load(self.value)
+
     @classmethod
     def from_string(cls, s):
         if not isinstance(s, six.string_types):
@@ -80,5 +84,5 @@ def interpolate(data):
             x = data
             for k in path[:-1]:
                 x = x[k]
-            x[path[-1]] = yaml.load(e.value)
+            x[path[-1]] = e.yaml_value
     return data

--- a/yamlenv/env.py
+++ b/yamlenv/env.py
@@ -1,6 +1,7 @@
 # pylint: disable=undefined-variable
 import os
 import re
+import yaml
 
 try:
     from collections.abc import Mapping, Sequence, Set
@@ -79,5 +80,5 @@ def interpolate(data):
             x = data
             for k in path[:-1]:
                 x = x[k]
-            x[path[-1]] = e.value
+            x[path[-1]] = yaml.load(e.value)
     return data


### PR DESCRIPTION
This change does alter the behaviour of some of the original tests - for the better, in my opinion, but a change in behaviour nonetheless.